### PR TITLE
#7 회계전표 조회 상세조회 버튼 나왔다가 사라지는 현상 수정

### DIFF
--- a/src/component/page/Accounting/AccSlip/AccSlipMain/AccSlipMain.tsx
+++ b/src/component/page/Accounting/AccSlip/AccSlipMain/AccSlipMain.tsx
@@ -17,6 +17,7 @@ export const AccSlipMain = () => {
     const [accSlipList, setAccSlipList] = useState<IAccSlip[]>([]);
     const [accSlipTotalCnt, setAccSlipTotalCnt] = useState<number>(0);
     const [modal, setModal] = useRecoilState(modalState);
+    const [showModalBtn, setShowModalBtn] = useState<boolean>(false);
 
     useEffect(() => {
         searchAccSlip();
@@ -36,6 +37,9 @@ export const AccSlipMain = () => {
             setAccSlipList(postSearchAccSlip.accSlipList);
             setAccSlipTotalCnt(postSearchAccSlip.accSlipTotalCnt);
             setCurrentPage(cpage);
+
+            if (searchCust.cust_id !== "all" && searchCust.cust_id !== "" && postSearchAccSlip.accSlipList.length > 0) setShowModalBtn(true);
+            else setShowModalBtn(false);
         }
     };
 
@@ -45,7 +49,7 @@ export const AccSlipMain = () => {
 
     return (
         <>
-            <AccSlipButtonStyled>{searchCust.cust_id !== "all" && searchCust.cust_id !== "" && accSlipList.length > 0 ? <Button onClick={handlerModal}>상세조회</Button> : null}</AccSlipButtonStyled>
+            <AccSlipButtonStyled>{showModalBtn ? <Button onClick={handlerModal}>상세조회</Button> : null}</AccSlipButtonStyled>
             <StyledTable>
                 <colgroup>
                     <col width="10%" />


### PR DESCRIPTION
### 문제 현상
거래처명 조건을 전체에서 개별 거래처로 선택하여 조회했을 때, 데이터가 없는 경우 상세조회 버튼이 나왔다가 사라짐
<br>

**[상세조회 버튼이 표시되는 경우]**
- 거래처명 검색 조건이 전체가 아니면서, 데이터가 있을 때

----

### 해결
회계전표 목록 데이터가 조회된 후, 조건에 따라 버튼 표시 여부 결정